### PR TITLE
<feat(api-gateway)>: Add login and register endpoints to api-gateway using AuthClient delegation

### DIFF
--- a/services/api-gateway/app/controllers/login.rb
+++ b/services/api-gateway/app/controllers/login.rb
@@ -1,0 +1,35 @@
+require 'json'
+require 'rack'
+require 'auth_client'
+require 'schemas/auth_schema'
+
+
+module AuthControllers
+    class LoginController
+        def self.call(env)
+            req = Rack::Request.new(env)
+            body = parse_body(req)
+            return body unless body.is_a?(Hash)
+
+            result = Schemas::LoginSchema.call(body)
+            unless result.success?
+                return respond(422, error: 'Invalid login data')
+            end
+
+            response = AuthClient.login(username: body['username'], password: body['password'])
+            return respond(401, error: 'Invalid credentials') unless response
+
+            respond(200, response)
+        end
+
+        def self.parse_body(req)
+            JSON.parse(req.body.read)
+        rescue JSON::ParserError
+            respond(400, error: 'Invalid JSON format')
+        end
+
+        def self.respond(status, body)
+            [status, { 'Content-Type' => 'application/json' }, [body.to_json]]
+        end
+    end
+end

--- a/services/api-gateway/app/controllers/register.rb
+++ b/services/api-gateway/app/controllers/register.rb
@@ -1,0 +1,35 @@
+require 'json'
+require 'rack'
+require 'auth_client'
+require 'schemas/auth_schema'
+
+
+module AuthControllers
+    class RegisterController
+        def self.call(env)
+            req = Rack::Request.new(env)
+            body = parse_body(req)
+            return body unless body.is_a?(Hash)
+
+            result = Schemas::RegisterSchema.call(body)
+            unless result.success?
+                return respond(422, error: 'Invalid registration data')
+            end
+
+            response = AuthClient.register(username: body['username'], password: body['password'])
+            return respond(422, error: 'Registration failed') unless response
+
+            respond(201, response)
+        end
+
+        def self.parse_body(req)
+            JSON.parse(req.body.read)
+            rescue JSON::ParserError
+            respond(400, error: 'Invalid JSON format')
+        end
+
+        def self.respond(status, body)
+            [status, { 'Content-Type' => 'application/json' }, [body.to_json]]
+        end
+    end
+end

--- a/services/api-gateway/app/routes.rb
+++ b/services/api-gateway/app/routes.rb
@@ -1,5 +1,7 @@
 require 'controllers/healthcheck'
 require 'controllers/products'
+require 'controllers/login'
+require 'controllers/register'
 
 module Routes
   def self.call(env)
@@ -8,6 +10,10 @@ module Routes
     case [req.request_method, req.path_info]
     when ['GET', '/healthcheck']
         HealthcheckController.call(env)
+    when ['POST', '/login']
+        AuthControllers::LoginController.call(env)
+    when ['POST', '/register']
+        AuthControllers::RegisterController.call(env)
     when ['POST', '/products']
         ProductsController.call(env)
     else

--- a/services/api-gateway/app/schemas/auth_schema.rb
+++ b/services/api-gateway/app/schemas/auth_schema.rb
@@ -1,0 +1,13 @@
+require 'dry-validation'
+
+module Schemas
+    LoginSchema = Dry::Schema.Params do
+        required(:username).filled(:string)
+        required(:password).filled(:string)
+    end
+
+    RegisterSchema = Dry::Schema.Params do
+        required(:username).filled(:string, min_size?: 3)
+        required(:password).filled(:string, min_size?: 6)
+    end
+end


### PR DESCRIPTION
## Description
This PR adds support for user authentication and registration through the api-gateway, delegating logic to the auth-service.

# New Endpoints
- POST /login
  - Validates JSON body with LoginSchema
  - Calls AuthClient.login and returns JWT on success
- POST /register
  - Validates JSON body with RegisterSchema
  - Calls AuthClient.register
  - Returns 201 on success, 422 on failure

# Utilities
- Adds auth_schema.rb with strong validation using dry-validation
- Routes integrated into central Routes module
- Controllers use a consistent respond helper for uniform JSON output

