### PR TITLE
<feat(api-gateway)>: Serve OpenAPI spec via /openapi.yaml with caching and ETag support

### DIFF
--- a/services/api-gateway/app/controllers/static_file.rb
+++ b/services/api-gateway/app/controllers/static_file.rb
@@ -1,0 +1,33 @@
+require 'digest'
+
+module StaticControllers
+  class StaticFileController
+    def self.call(env)
+      req = Rack::Request.new(env)
+
+      return not_found unless req.path_info == '/openapi.yaml'
+
+      path = File.expand_path('../../../static/openapi.yaml', __FILE__)
+      return not_found unless File.exist?(path)
+
+      content = File.read(path)
+      etag = %("#{Digest::SHA256.hexdigest(content)}")
+
+      if req.get_header('HTTP_IF_NONE_MATCH') == etag
+        return [304, { 'ETag' => etag }, []]
+      end
+
+      headers = {
+        'Content-Type' => 'application/yaml',
+        'Cache-Control' => 'no-store',
+        'ETag' => etag
+      }
+
+      [200, headers, [content]]
+    end
+
+    def self.not_found
+      [404, { 'Content-Type' => 'application/json' }, [{ error: 'File not found' }.to_json]]
+    end
+  end
+end

--- a/services/api-gateway/app/routes.rb
+++ b/services/api-gateway/app/routes.rb
@@ -3,12 +3,15 @@ require 'controllers/products_create'
 require 'controllers/products_index'
 require 'controllers/login'
 require 'controllers/register'
+require 'controllers/static_file'
 
 module Routes
   def self.call(env)
     req = Rack::Request.new(env)
 
     case [req.request_method, req.path_info]
+    when ['GET', '/openapi.yaml']
+        StaticControllers::StaticFileController.call(env)
     when ['GET', '/healthcheck']
         HealthcheckController.call(env)
     when ['POST', '/login']

--- a/services/api-gateway/static/openapi.yaml
+++ b/services/api-gateway/static/openapi.yaml
@@ -1,0 +1,203 @@
+openapi: 3.0.3
+info:
+  title: API Gateway Fudo
+  description: >
+    API that exposes login, registration, and asynchronous product creation and listing
+  version: 1.0.0
+
+servers:
+  - url: http://localhost:8080
+    description: Local development environment
+
+tags:
+  - name: Auth
+    description: Login and registration
+  - name: Products
+    description: Asynchronous product management
+
+paths:
+  /login:
+    post:
+      tags:
+        - Auth
+      summary: Log in
+      description: >
+        Receives user credentials and returns a JWT token.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+            example:
+              username: "miguel"
+              password: "123456"
+      responses:
+        '200':
+          description: >
+            JWT token. The response will be gzip-compressed if the request includes the Accept-Encoding: gzip header.
+          content:
+            application/json:
+              example:
+                token: "Bearer eyJhbGci..."
+        '400':
+          description: Invalid JSON
+        '401':
+          description: Invalid credentials
+        '422':
+          description: Invalid login data
+      parameters:
+        - $ref: '#/components/parameters/Accept-Encoding'
+
+  /register:
+    post:
+      tags:
+        - Auth
+      summary: Register a new user
+      description: >
+        Creates a new user with username and password.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterRequest'
+            example:
+              username: "miguel"
+              password: "123456"
+      responses:
+        '201':
+          description: >
+            User successfully created. The response will be gzip-compressed if the request includes the Accept-Encoding: gzip header.
+          content:
+            application/json:
+              example:
+                status: "User created"
+        '400':
+          description: Invalid JSON
+        '422':
+          description: Invalid registration data
+      parameters:
+        - $ref: '#/components/parameters/Accept-Encoding'
+
+  /products:
+    get:
+      tags:
+        - Products
+      summary: Get products
+      description: >
+        Retrieves the list of products for the authenticated user.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: >
+            List of products. The response will be gzip-compressed if the request includes the Accept-Encoding: gzip header.
+          content:
+            application/json:
+              example:
+                - id: 1
+                  name: "Coca-Cola 500ml"
+                - id: 2
+                  name: "Pepsi 1000ml"
+        '401':
+          description: Unauthorized
+        '502':
+          description: Could not fetch products
+      parameters:
+        - $ref: '#/components/parameters/Accept-Encoding'
+
+    post:
+      tags:
+        - Products
+      summary: Create product
+      description: >
+        Sends a new product to be created asynchronously.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProductRequest'
+            example:
+              name: "Coca-Cola 500ml"
+      responses:
+        '202':
+          description: >
+            Product creation accepted. The response will be gzip-compressed if the request includes the Accept-Encoding: gzip header.
+          content:
+            application/json:
+              example:
+                status: "Product is being created"
+        '400':
+          description: Invalid JSON
+        '401':
+          description: Unauthorized
+        '422':
+          description: Invalid product data
+      parameters:
+        - $ref: '#/components/parameters/Accept-Encoding'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  parameters:
+    Accept-Encoding:
+      name: Accept-Encoding
+      in: header
+      description: Ask the server to respond with gzip-compressed content
+      required: false
+      schema:
+        type: string
+        example: gzip
+
+  schemas:
+    LoginRequest:
+      type: object
+      required:
+        - username
+        - password
+      properties:
+        username:
+          type: string
+          example: "miguel"
+        password:
+          type: string
+          example: "123456"
+
+    RegisterRequest:
+      type: object
+      required:
+        - username
+        - password
+      properties:
+        username:
+          type: string
+          minLength: 3
+          example: "miguel"
+        password:
+          type: string
+          minLength: 6
+          example: "123456"
+
+    ProductRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          example: "Coca-Cola 500ml"
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          example: "Unauthorized"


### PR DESCRIPTION
## Description:
This PR adds a new static endpoint to the API Gateway that serves the openapi.yaml specification. Key features:

- Adds a StaticFileController to respond to GET /openapi.yaml.
- Includes ETag-based conditional responses for efficient client-side caching (returns 304 Not Modified when applicable).
- Adds the actual OpenAPI spec file (static/openapi.yaml), documenting all key routes (auth and product management), security, and request/response examples.
- Integrates the new controller into routes.rb.

This allows clients and developers to programmatically fetch or view the API contract, improving observability and documentation.